### PR TITLE
Downgrade h5py in requirements.txt and fix module error in annotate.py

### DIFF
--- a/annotate.py
+++ b/annotate.py
@@ -6,6 +6,7 @@ import json
 import os
 from keras.preprocessing.image import load_img
 from keras.preprocessing.image import img_to_array
+from mrcnn import utils
 from mrcnn.visualize import display_instances
 from mrcnn.config import Config
 from mrcnn.model import MaskRCNN

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ scikit-image
 tensorflow==1.15
 keras==2.0.8
 opencv-python
-h5py
+h5py==2.10.0
 imgaug
 Shapely
 IPython[all]


### PR DESCRIPTION
Fixes #24. Also added an import statement to `annotate.py` to fix a `no module named 'utils'` error when I was trying to run `annotate.py`.